### PR TITLE
change compile helper return promise

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,8 +143,8 @@ tests whether a directory contains a file with a given filename
 ##### directory.matches_dir(path, path2)
 tests whether a directory's contents match that of a second directory
 
-##### project.compile(Roots, path, callback)
-compiles a roots project given the `Roots` class, a path for the project, and a callback
+##### project.compile(Roots, path)
+returns a promise, compiles a roots project given the `Roots` class and a path for the project.
 
 ##### project.remove_folders(minimatchString)
 given a minimatch string, removes all folders that match (good for removing public folders after tests have completed)

--- a/lib/test_helpers.coffee
+++ b/lib/test_helpers.coffee
@@ -60,11 +60,8 @@ class Helpers
         String(fs.readdirSync(dir)) == String(fs.readdirSync(expected))
 
     @project =
-      compile: (Roots, p, cb) ->
-        project = new Roots(_path(p))
-        project.on('error', cb)
-        project.on('done', cb)
-        project.compile()
+      compile: (Roots, p) ->
+        new Roots(_path(p)).compile()
       remove_folders: (matcher) ->
         rimraf.sync(dir) for dir in glob.sync(_path(matcher))
       install_dependencies: (base, cb) ->

--- a/test/test.coffee
+++ b/test/test.coffee
@@ -169,7 +169,7 @@ describe 'helpers', ->
     @h2.directory.matches_dir('helpers/folda', 'helpers/identical_folda').should.be.ok
 
   it 'project.compile should work', (done) ->
-    @h1.project.compile Roots, path.join(_path, 'helpers'), =>
+    @h1.project.compile(Roots, path.join(_path, 'helpers')).then =>
       @h1.directory.exists(path.join(_path, 'helpers/public')).should.be.ok
       done()
 


### PR DESCRIPTION
This updates the compile helper to pass its callback arguments using the node convention of an error as the first arg and a successful return value as the second. This allows easy usage with `node.call` which is used for example in https://github.com/carrot/roots-contentful/commit/cbfa46660d554be835b05e2e9edb8e71f95b42da
